### PR TITLE
[3.x][bug] HasWidth compatible with caused errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ use Yepsua\Filament\Forms\Components\Rating
 * ->clearIcon(): Set the icon for the clear action.
 * ->min(): Set the min value for the rating field. Default: 1
 * ->max(): Set the max value for the rating field. Default: 5
-* ->width(): Set the width value for each item in the field: Default: 6
-* ->height(): Set the height value for each item in the field: Default: 6
-* ->size(): Set the same value for the width and height properties.
+* ->classWidth(): Set the width value for each item in the field: Default: 6
+* ->classHeight(): Set the height value for each item in the field: Default: 6
+* ->classSize(): Set the same value for the width and height properties.
 * ->effects(): Enable\Disable the mouseenter and mouseleave effects. Default: true (enabled)
 * ->clearable(): Add a extra icon at the end of the rating icons. Default: false
 * ->cursor(): Set the default cursor
@@ -284,9 +284,9 @@ protected function getTableColumns(): array
 * ``` RatingColumn::make('rating')->icons() ``` Set the icons for the default items and for selected items.
 * ``` RatingColumn::make('rating')->minValue() ``` Set the min value for the rating field. Default: 1
 * ``` RatingColumn::make('rating')->maxValue() ``` Set the max value for the rating field. Default: 5
-* ``` RatingColumn::make('rating')->width() ``` Set the width value for each item in the field: Default: 6
-* ``` RatingColumn::make('rating')->height() ``` Set the height value for each item in the field: Default: 6
-* ``` RatingColumn::make('rating')->size() ``` Set the same value for the width and height properties.
+* ``` RatingColumn::make('rating')->classWidth() ``` Set the width value for each item in the field: Default: 6
+* ``` RatingColumn::make('rating')->classHeight() ``` Set the height value for each item in the field: Default: 6
+* ``` RatingColumn::make('rating')->classSize() ``` Set the same value for the width and height properties.
 * ``` RatingColumn::make('rating')->options() ``` set tooltip
 
 ![filament-page-with-sidebar](./images/rating-column.png)

--- a/src/Forms/Components/Rating.php
+++ b/src/Forms/Components/Rating.php
@@ -18,8 +18,8 @@ class Rating extends Field
     protected string $clearIcon = "heroicon-s-x-circle";
     protected int | Closure $min = 1;
     protected int | Closure $max = 5;
-    protected int | Closure $width = 6;
-    protected int | Closure $height = 6;
+    protected int | Closure $classWidth = 6;
+    protected int | Closure $classHeight = 6;
     protected bool | Closure $effects = true;
     protected bool | Closure $clearable = false;
     protected string $cursor = 'pointer';
@@ -122,24 +122,24 @@ class Rating extends Field
         return $this->tooltips[$index - 1] ?? '';
     }
 
-    public function width(int | Closure $width): self
+    public function classWidth(int | Closure $width): self
     {
-        $this->width = $width;
+        $this->classWidth = $width;
 
         return $this;
     }
 
-    public function height(int | Closure $height): self
+    public function classHeight(int | Closure $height): self
     {
-        $this->height = $height;
+        $this->classHeight = $height;
 
         return $this;
     }
 
-    public function size(int | Closure $size): self
+    public function classSize(int | Closure $size): self
     {
-        $this->width = $size;
-        $this->height = $size;
+        $this->classWidth = $size;
+        $this->classHeight = $size;
 
         return $this;
     }
@@ -217,14 +217,14 @@ class Rating extends Field
         return $this->evaluate($this->max);
     }
 
-    public function getWidth(): int
+    public function getClassWidth(): int
     {
-        return $this->evaluate($this->width);
+        return $this->evaluate($this->classWidth);
     }
 
-    public function getHeight(): int
+    public function getClassHeight(): int
     {
-        return $this->evaluate($this->height);
+        return $this->evaluate($this->classHeight);
     }
 
     public function getCursor(): string
@@ -268,7 +268,7 @@ class Rating extends Field
 
     public function getSizeClass(): string
     {
-        return sprintf('w-%s h-%s', $this->getWidth(), $this->getHeight());
+        return sprintf('w-%s h-%s', $this->getClassWidth(), $this->getClassHeight());
     }
 
     public function getCursorClass(): string

--- a/src/Tables/Components/RatingColumn.php
+++ b/src/Tables/Components/RatingColumn.php
@@ -17,8 +17,8 @@ class RatingColumn extends Column
     protected string | Closure $selectedIcon = "heroicon-s-star";
     protected int | Closure $min = 1;
     protected int | Closure $max = 5;
-    protected int | Closure $width = 6;
-    protected int | Closure $height = 6;
+    protected int | Closure $classWidth = 6;
+    protected int | Closure $classHeight = 6;
     protected string $cursor = 'default';
     protected string $clearIconTooltip = "";
     protected array $tooltips = [];
@@ -102,24 +102,24 @@ class RatingColumn extends Column
         return $this->tooltips[$index - 1] ?? '';
     }
 
-    public function width(int | Closure $width): self
+    public function classWidth(int | Closure $width): self
     {
-        $this->width = $width;
+        $this->classWidth = $width;
 
         return $this;
     }
 
-    public function height(int | Closure $height): self
+    public function classHeight(int | Closure $height): self
     {
-        $this->height = $height;
+        $this->classHeight = $height;
 
         return $this;
     }
 
-    public function size(int | Closure $size): self
+    public function classSize(int | Closure $size): self
     {
-        $this->width = $size;
-        $this->height = $size;
+        $this->classWidth = $size;
+        $this->classHeight = $size;
 
         return $this;
     }
@@ -159,14 +159,14 @@ class RatingColumn extends Column
         return $this->evaluate($this->max);
     }
 
-    public function getWidth(): int
+    public function getClassWidth(): int
     {
-        return $this->evaluate($this->width);
+        return $this->evaluate($this->classWidth);
     }
 
-    public function getHeight(): int
+    public function getClassHeight(): int
     {
-        return $this->evaluate($this->height);
+        return $this->evaluate($this->classHeight);
     }
 
     public function getCursor(): string
@@ -188,7 +188,7 @@ class RatingColumn extends Column
 
     public function getSizeClass(): string
     {
-        return sprintf('w-%s h-%s', $this->getWidth(), $this->getHeight());
+        return sprintf('w-%s h-%s', $this->getClassWidth(), $this->getClassHeight());
     }
 
     public function getCursorClass(): string


### PR DESCRIPTION
This package is really helpful when I built some features in my project, but I found some problems and fixed it, the errors is caused by filament3.x new features: `Filament\Tables\Columns\Concerns\HasWidth` that had the same name that `getWidth` and `width`, property `width` with the package, so I fixed it quickly and hoping merge this PR to help other users enjoying.


I changed the name and add a prefix `class` to prevent compatible problem and more specify to set css class for rendering, also I changed names in `form` and `table`, I think it more consistency to use, and the `size` it does the same thing, so I changed it too.

I also updated readme. To be notice, this PR is breaking changes, so I highly recommend add tag for 3.x.