### PR TITLE
Update type definitions for RatingColumn::$width

### DIFF
--- a/src/Tables/Components/RatingColumn.php
+++ b/src/Tables/Components/RatingColumn.php
@@ -17,7 +17,7 @@ class RatingColumn extends Column
     protected string | Closure $selectedIcon = "heroicon-s-star";
     protected int | Closure $min = 1;
     protected int | Closure $max = 5;
-    protected int | Closure $width = 6;
+    protected int | string | Closure | null $width = 6;
     protected int | Closure $height = 6;
     protected string $cursor = 'default';
     protected string $clearIconTooltip = "";
@@ -100,13 +100,6 @@ class RatingColumn extends Column
     public function getRateTooltip(int $index): mixed
     {
         return $this->tooltips[$index - 1] ?? '';
-    }
-
-    public function width(int | Closure $width): self
-    {
-        $this->width = $width;
-
-        return $this;
     }
 
     public function height(int | Closure $height): self


### PR DESCRIPTION
### Description

**Removed `width` Method:**
- The `width` method has been completely removed from `Yepsua\Filament\Tables\Components\RatingColumn` as it was redundant. The method is identical to the one provided in the base class through the `HasWidth` trait.

**Updated Type Definitions:**
- Adjusted the type definitions for the `$width` property in `Yepsua\Filament\Tables\Components\RatingColumn` to ensure compatibility with the base class `Filament\Tables\Columns\Column`. The types now correctly reflect `Closure|string|int|null`.

### Reason for Changes

- **Redundancy Removal:** Removing the duplicate `width` method simplifies the code. The base class already provides the necessary functionality.
- **Type Compatibility:** The type definitions were inconsistent with the base class, leading to errors. This update ensures that the types are aligned, preventing such errors. (Especially when using strict types.)

### Testing

- **Manual Testing:** Verified that removing the method does not affect functionality, as the base class's method is the same.
- **Type Checking:** Ensured that the updated type definitions eliminate the previously encountered errors.

@renderse7en was facing the same issue in #19 
